### PR TITLE
Add simple counter to React frontend

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Counter from './Counter';
 import './App.css';
 
 const App = () => {
@@ -37,6 +38,8 @@ const App = () => {
         <p>{fact}</p>
         <button onClick={fetchFact}>New Fact</button>
       </div>
+
+      <Counter />
     </div>
   );
 };

--- a/frontend/src/Counter.js
+++ b/frontend/src/Counter.js
@@ -1,0 +1,16 @@
+import React, { useState } from 'react';
+
+const Counter = () => {
+  const [count, setCount] = useState(0);
+
+  return (
+    <div className="card">
+      <h2>Counter</h2>
+      <p>{count}</p>
+      <button onClick={() => setCount(count + 1)}>Increase</button>
+      <button onClick={() => setCount(count - 1)} style={{ marginLeft: '10px' }}>Decrease</button>
+    </div>
+  );
+};
+
+export default Counter;


### PR DESCRIPTION
## Summary
- add a new `Counter` component with increment and decrement buttons
- include `Counter` in the main `App`

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e14527ec832697ce2824137a1f07